### PR TITLE
Compute booking permissions for admin list actions

### DIFF
--- a/server.js
+++ b/server.js
@@ -4956,6 +4956,9 @@ app.get('/admin/bookings', requireLogin, requirePermission('bookings.view'), (re
   `;
   const rows = db.prepare(sql).all(...args);
 
+  const canEditBooking = userCan(req.user, 'bookings.edit');
+  const canCancelBooking = userCan(req.user, 'bookings.cancel');
+
   res.send(layout({
     title: 'Reservas',
     user: req.user,


### PR DESCRIPTION
## Summary
- compute booking edit and cancel permissions in the admin bookings list
- ensure the action links render according to the viewer's privileges

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0358c47288331919b262fb30e32af