### PR TITLE
Restrict debug routes listing

### DIFF
--- a/server.js
+++ b/server.js
@@ -2614,26 +2614,28 @@ registerFrontoffice(app, context);
 registerBackoffice(app, context);
 
 // ===================== Debug Rotas + 404 =====================
-app.get('/_routes', (req, res) => {
-  const router = app._router;
-  if (!router || !router.stack) return res.type('text/plain').send('(router não inicializado)');
-  const lines = [];
-  router.stack.forEach(mw => {
-    if (mw.route && mw.route.path) {
-      const methods = Object.keys(mw.route.methods).map(m => m.toUpperCase()).join(',');
-      lines.push(`${methods} ${mw.route.path}`);
-    } else if (mw.name === 'router' && mw.handle && mw.handle.stack) {
-      mw.handle.stack.forEach(r => {
-        const rt = r.route;
-        if (rt && rt.path) {
-          const methods = Object.keys(rt.methods).map(m => m.toUpperCase()).join(',');
-          lines.push(`${methods} ${rt.path}`);
-        }
-      });
-    }
+if (process.env.NODE_ENV !== 'production') {
+  app.get('/_routes', requireAdmin, (req, res) => {
+    const router = app._router;
+    if (!router || !router.stack) return res.type('text/plain').send('(router não inicializado)');
+    const lines = [];
+    router.stack.forEach(mw => {
+      if (mw.route && mw.route.path) {
+        const methods = Object.keys(mw.route.methods).map(m => m.toUpperCase()).join(',');
+        lines.push(`${methods} ${mw.route.path}`);
+      } else if (mw.name === 'router' && mw.handle && mw.handle.stack) {
+        mw.handle.stack.forEach(r => {
+          const rt = r.route;
+          if (rt && rt.path) {
+            const methods = Object.keys(rt.methods).map(m => m.toUpperCase()).join(',');
+            lines.push(`${methods} ${rt.path}`);
+          }
+        });
+      }
+    });
+    res.type('text/plain').send(lines.sort().join('\n') || '(sem rotas)');
   });
-  res.type('text/plain').send(lines.sort().join('\n') || '(sem rotas)');
-});
+}
 
 app.use((req, res) => {
   res.status(404).send(context.layout({ body: '<h1 class="text-xl font-semibold">404</h1><p>Página não encontrada.</p>' }));


### PR DESCRIPTION
## Summary
- gate the /_routes debug endpoint behind admin authentication and disable it in production builds

## Testing
- curl -i http://localhost:3000/_routes

------
https://chatgpt.com/codex/tasks/task_e_68e195375f6c8331a6705d3f31ac4331